### PR TITLE
Fix for production (move Dockerfile)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
 
 COPY . .
 
-RUN pip3 install -r requirements.txt
+RUN pip3 install -r ui/requirements.txt
 
 EXPOSE 8501
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ EXPOSE 8501
 
 HEALTHCHECK CMD curl --fail http://localhost:8501/_stcore/health
 
-ENTRYPOINT ["streamlit", "run", "main.py", "--server.port=8501", "--server.address=0.0.0.0"]
+ENTRYPOINT ["streamlit", "run", "ui/main.py", "--server.port=8501", "--server.address=0.0.0.0"]


### PR DESCRIPTION
Moving Docker file to the root folder, to be compatible with system used to build the production image.