### PR TITLE
Increase Streamlit upload size

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -3,4 +3,4 @@
 # Max size, in megabytes, for files uploaded with the file_uploader.
 
 # Default: 200
-maxUploadSize = 50
+maxUploadSize = 100


### PR DESCRIPTION
Increasing max upload size to 100 MB.