### PR TITLE
Force reload the DSD

### DIFF
--- a/ui/common_elements.py
+++ b/ui/common_elements.py
@@ -115,10 +115,10 @@ def make_passed_status_message(all_passed: bool, all_included: bool) -> str:
     all_included_message: str
     if all_passed:
         all_passed_message = '<p style="font-weight: bold">Status: ' \
-            '<span style="color: green">All AR6 checks passed</span></p>'
+            '<span style="color: green">All checks passed</span></p>'
     else:
         all_passed_message = '<p style="font-weight: bold">Status: ' \
-            '<span style="color: red">Some AR6 checks failed</span></p>'
+            '<span style="color: red">Some checks failed</span></p>'
     if all_included:
         all_included_message = '<p style="font-weight: bold">Coverage: ' \
             '<span style="color: green">All models/scenarios assessed for ' \

--- a/ui/p/Validation_run_and_summary.py
+++ b/ui/p/Validation_run_and_summary.py
@@ -55,7 +55,8 @@ def main():
         if button_field.button('Run name checks'):
             button_field.empty()
             dsd: DataStructureDefinition = \
-                get_validation_dsd(allow_load=True, show_spinner=True)
+                get_validation_dsd(force_load=True, allow_load=True,
+                                   show_spinner=True)
             dsd_dims: list[str] = [str(_dim) for _dim in dsd.dimensions]
             non_region_dims: list[str] = [_dim for _dim in dsd_dims
                                            if _dim != 'region']


### PR DESCRIPTION
The datastructure definitions are being cached indefinitely, which means that changes to the definitions don't get picked up unless the server instance is restarted. This PR instead forces the DSD to be reloaded every time the naming validation checks are run.

This adds a few seconds of run time to the validation step, but is probably the best we can do for now. The next step would be to check the hash of the currently cached commit of each DSD that is loaded from a repository, but that would require more time to code than is currently available.

The PR also corrects a text label on the vetting pages.